### PR TITLE
Mockup 서버 기본 구현 완료

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/server/src/main/java/com/konkuk/soar/SoarApplication.java
+++ b/server/src/main/java/com/konkuk/soar/SoarApplication.java
@@ -2,7 +2,9 @@ package com.konkuk.soar;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class SoarApplication {
 

--- a/server/src/main/java/com/konkuk/soar/common/config/OpenApiConfig.java
+++ b/server/src/main/java/com/konkuk/soar/common/config/OpenApiConfig.java
@@ -1,0 +1,20 @@
+package com.konkuk.soar.common.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    Info info = new Info()
+        .version("v1.0.0")
+        .title("API title")
+        .description("API Description");
+    return new OpenAPI()
+        .info(info);
+  }
+}

--- a/server/src/main/java/com/konkuk/soar/common/domain/BaseTime.java
+++ b/server/src/main/java/com/konkuk/soar/common/domain/BaseTime.java
@@ -1,0 +1,20 @@
+package com.konkuk.soar.common.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class BaseTime {
+
+  @CreatedDate
+  private LocalDateTime createAt;
+  @LastModifiedDate
+  private LocalDateTime updateAt;
+}

--- a/server/src/main/java/com/konkuk/soar/common/dto/BaseResponse.java
+++ b/server/src/main/java/com/konkuk/soar/common/dto/BaseResponse.java
@@ -25,12 +25,14 @@ public class BaseResponse<T> {
   private T result;
 
   // 200
-  public BaseResponse(T result) {
+  protected BaseResponse(T result) {
     this.isSuccess = SUCCESS.isSuccess();
     this.status = SUCCESS.getStatus();
     this.message = SUCCESS.getMessage();
     this.result = result;
   }
 
-
+  public static <G> BaseResponse<G> success(G result) {
+    return new BaseResponse<>(result);
+  }
 }

--- a/server/src/main/java/com/konkuk/soar/common/dto/file/response/FileResponseDto.java
+++ b/server/src/main/java/com/konkuk/soar/common/dto/file/response/FileResponseDto.java
@@ -3,8 +3,10 @@ package com.konkuk.soar.common.dto.file.response;
 import com.konkuk.soar.common.domain.File;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class FileResponseDto {
 
   private Long fileId;

--- a/server/src/main/java/com/konkuk/soar/common/dto/tag/response/TagListResponseDto.java
+++ b/server/src/main/java/com/konkuk/soar/common/dto/tag/response/TagListResponseDto.java
@@ -6,8 +6,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class TagListResponseDto {
 
   private List<String> name;

--- a/server/src/main/java/com/konkuk/soar/common/enums/FileType.java
+++ b/server/src/main/java/com/konkuk/soar/common/enums/FileType.java
@@ -1,0 +1,21 @@
+package com.konkuk.soar.common.enums;
+
+public enum FileType {
+  TIMELAPSE("timelapse"),
+  NORMAL("normal");
+
+  private final String name;
+
+  FileType(String name) {
+    this.name = name;
+  }
+
+  public static FileType of(String name) {
+    for (FileType fileType : FileType.values()) {
+      if (fileType.name.equalsIgnoreCase(name)) {
+        return fileType;
+      }
+    }
+    throw new IllegalArgumentException("NO FileType found for name:" + name);
+  }
+}

--- a/server/src/main/java/com/konkuk/soar/global/exception/NotFoundException.java
+++ b/server/src/main/java/com/konkuk/soar/global/exception/NotFoundException.java
@@ -1,5 +1,13 @@
 package com.konkuk.soar.global.exception;
 
 public class NotFoundException extends RuntimeException {
-  public static NotFoundException MEMBER_NOT_FOUND = new NotFoundException();
+
+  public static NotFoundException MEMBER_NOT_FOUND = new NotFoundException(
+      "Invalid ID : Member Not Found");
+  public static NotFoundException STUDY_HISTORY_NOT_FOUND = new NotFoundException(
+      "Invalid ID : StudyHistoy Not Found");
+
+  public NotFoundException(String message) {
+    super(message);
+  }
 }

--- a/server/src/main/java/com/konkuk/soar/global/exception/NotFoundException.java
+++ b/server/src/main/java/com/konkuk/soar/global/exception/NotFoundException.java
@@ -1,0 +1,5 @@
+package com.konkuk.soar.global.exception;
+
+public class NotFoundException extends RuntimeException {
+  public static NotFoundException MEMBER_NOT_FOUND = new NotFoundException();
+}

--- a/server/src/main/java/com/konkuk/soar/portfolio/controller/PortfolioController.java
+++ b/server/src/main/java/com/konkuk/soar/portfolio/controller/PortfolioController.java
@@ -1,0 +1,36 @@
+package com.konkuk.soar.portfolio.controller;
+
+import com.konkuk.soar.common.dto.BaseResponse;
+import com.konkuk.soar.portfolio.dto.portfolio.response.PortfolioResponseDto;
+import com.konkuk.soar.portfolio.enums.OptionType;
+import com.konkuk.soar.portfolio.service.PortfolioService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/portfolios")
+public class PortfolioController {
+
+  private final PortfolioService portfolioService;
+
+  @GetMapping("/{portfolioId}")
+  BaseResponse getPortfolio(@PathVariable Long portfolioId) {
+    PortfolioResponseDto result = portfolioService.getPortfolioById(portfolioId);
+    return BaseResponse.success(result);
+  }
+
+  @GetMapping
+  BaseResponse getPortfolioList(@RequestParam Long memberId, @RequestParam String option,
+      @RequestParam(required = false, defaultValue = "5") Integer size) {
+    OptionType optionType = OptionType.of(option);
+    List<PortfolioResponseDto> result = portfolioService.getPortfolioListByMember(
+        memberId, optionType, size);
+    return BaseResponse.success(result);
+  }
+}

--- a/server/src/main/java/com/konkuk/soar/portfolio/controller/PortfolioController.java
+++ b/server/src/main/java/com/konkuk/soar/portfolio/controller/PortfolioController.java
@@ -20,13 +20,13 @@ public class PortfolioController {
   private final PortfolioService portfolioService;
 
   @GetMapping("/{portfolioId}")
-  BaseResponse getPortfolio(@PathVariable Long portfolioId) {
+  public BaseResponse<PortfolioResponseDto> getPortfolio(@PathVariable Long portfolioId) {
     PortfolioResponseDto result = portfolioService.getPortfolioById(portfolioId);
     return BaseResponse.success(result);
   }
 
   @GetMapping
-  BaseResponse getPortfolioList(@RequestParam Long memberId, @RequestParam String option,
+  public BaseResponse<List<PortfolioResponseDto>> getPortfolioList(@RequestParam Long memberId, @RequestParam String option,
       @RequestParam(required = false, defaultValue = "5") Integer size) {
     OptionType optionType = OptionType.of(option);
     List<PortfolioResponseDto> result = portfolioService.getPortfolioListByMember(

--- a/server/src/main/java/com/konkuk/soar/portfolio/controller/ProjectController.java
+++ b/server/src/main/java/com/konkuk/soar/portfolio/controller/ProjectController.java
@@ -1,0 +1,8 @@
+package com.konkuk.soar.portfolio.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ProjectController {
+
+}

--- a/server/src/main/java/com/konkuk/soar/portfolio/domain/portfolio/Portfolio.java
+++ b/server/src/main/java/com/konkuk/soar/portfolio/domain/portfolio/Portfolio.java
@@ -1,5 +1,6 @@
 package com.konkuk.soar.portfolio.domain.portfolio;
 
+import com.konkuk.soar.common.domain.BaseTime;
 import com.konkuk.soar.member.domain.Member;
 import com.konkuk.soar.portfolio.domain.project.Project;
 import jakarta.persistence.Column;
@@ -28,7 +29,7 @@ import org.hibernate.validator.constraints.Length;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "portfolios")
-public class Portfolio {
+public class Portfolio extends BaseTime {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/server/src/main/java/com/konkuk/soar/portfolio/dto/portfolio/response/PortfolioMetaResponseDto.java
+++ b/server/src/main/java/com/konkuk/soar/portfolio/dto/portfolio/response/PortfolioMetaResponseDto.java
@@ -1,8 +1,0 @@
-package com.konkuk.soar.portfolio.dto.portfolio.response;
-
-import lombok.Getter;
-
-@Getter
-public class PortfolioMetaResponseDto {
-
-}

--- a/server/src/main/java/com/konkuk/soar/portfolio/dto/portfolio/response/PortfolioOverviewDto.java
+++ b/server/src/main/java/com/konkuk/soar/portfolio/dto/portfolio/response/PortfolioOverviewDto.java
@@ -1,0 +1,39 @@
+package com.konkuk.soar.portfolio.dto.portfolio.response;
+
+import com.konkuk.soar.common.domain.Tag;
+import com.konkuk.soar.common.dto.tag.response.TagListResponseDto;
+import com.konkuk.soar.member.domain.Member;
+import com.konkuk.soar.portfolio.domain.portfolio.Portfolio;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PortfolioOverviewDto {
+
+  private Long portfolioId;
+  private Long memberId;
+  private String title;
+  private String description;
+  private String category;
+  private Integer bookmark;
+
+  private TagListResponseDto tags;
+
+  @Builder
+  public PortfolioOverviewDto(Portfolio portfolio, Member member,
+      List<Tag> tagList, Integer bookmark) {
+    this.portfolioId = portfolio.getId();
+    this.memberId = member.getId();
+    this.title = portfolio.getTitle();
+    this.description = portfolio.getDescription();
+    this.category = portfolio.getCategory();
+    this.bookmark = bookmark;
+
+    this.tags = TagListResponseDto.builder()
+        .tagList(tagList)
+        .build();
+  }
+}

--- a/server/src/main/java/com/konkuk/soar/portfolio/dto/portfolio/response/PortfolioResponseDto.java
+++ b/server/src/main/java/com/konkuk/soar/portfolio/dto/portfolio/response/PortfolioResponseDto.java
@@ -9,16 +9,19 @@ import com.konkuk.soar.portfolio.dto.project.response.ProjectResponseDto;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /*
 특정 Portfolio 조회 요청에 대한 응답 DTO
  */
 @Getter
+@NoArgsConstructor
 public class PortfolioResponseDto {
 
   private Long portfolioId;
-  private Long member_id;
+  private Long memberId;
   private String title;
   private String description;
   private String category;
@@ -29,11 +32,12 @@ public class PortfolioResponseDto {
   private TagListResponseDto tags;
 
   // TODO : projects 만 dto로 받는 상황 해결
+  @Builder
   public PortfolioResponseDto(Portfolio portfolio, Member member,
       List<ProjectResponseDto> projectList,
       List<PortfolioReview> reviewList, List<Tag> tagList, Integer bookmark) {
     this.portfolioId = portfolio.getId();
-    this.member_id = member.getId();
+    this.memberId = member.getId();
     this.title = portfolio.getTitle();
     this.description = portfolio.getDescription();
     this.category = portfolio.getCategory();

--- a/server/src/main/java/com/konkuk/soar/portfolio/dto/portfolio/response/PortfolioReviewResponseDto.java
+++ b/server/src/main/java/com/konkuk/soar/portfolio/dto/portfolio/response/PortfolioReviewResponseDto.java
@@ -5,8 +5,10 @@ import com.konkuk.soar.portfolio.domain.portfolio.Portfolio;
 import com.konkuk.soar.portfolio.domain.portfolio.PortfolioReview;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class PortfolioReviewResponseDto {
 
   private Long memberId;

--- a/server/src/main/java/com/konkuk/soar/portfolio/dto/project/response/ProjectMetaResponseDto.java
+++ b/server/src/main/java/com/konkuk/soar/portfolio/dto/project/response/ProjectMetaResponseDto.java
@@ -6,8 +6,10 @@ import com.konkuk.soar.portfolio.domain.project.Project;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class ProjectMetaResponseDto {
 
   private Long projectId;

--- a/server/src/main/java/com/konkuk/soar/portfolio/dto/project/response/ProjectResponseDto.java
+++ b/server/src/main/java/com/konkuk/soar/portfolio/dto/project/response/ProjectResponseDto.java
@@ -13,8 +13,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class ProjectResponseDto {
 
   private Long projectId;

--- a/server/src/main/java/com/konkuk/soar/portfolio/dto/project/response/ProjectResponseDto.java
+++ b/server/src/main/java/com/konkuk/soar/portfolio/dto/project/response/ProjectResponseDto.java
@@ -7,7 +7,7 @@ import com.konkuk.soar.member.domain.Member;
 import com.konkuk.soar.portfolio.domain.portfolio.Portfolio;
 import com.konkuk.soar.portfolio.domain.project.Project;
 import com.konkuk.soar.studyhistory.domain.StudyHistory;
-import com.konkuk.soar.studyhistory.dto.response.StudyHistoryMetaResponseDto;
+import com.konkuk.soar.studyhistory.dto.response.StudyHistoryOverviewDto;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -29,7 +29,7 @@ public class ProjectResponseDto {
   private LocalDateTime startDate;
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH", timezone = "Asia/Seoul")
   private LocalDateTime endDate;
-  private List<StudyHistoryMetaResponseDto> studyHistories;
+  private List<StudyHistoryOverviewDto> studyHistories;
   private List<FileResponseDto> files;
 
   @Builder
@@ -47,7 +47,7 @@ public class ProjectResponseDto {
 
     if (studyHistoryList != null) {
       this.studyHistories = studyHistoryList.stream()
-          .map(studyHistory -> StudyHistoryMetaResponseDto.builder()
+          .map(studyHistory -> StudyHistoryOverviewDto.builder()
               .member(member)
               .history(studyHistory)
               .build())

--- a/server/src/main/java/com/konkuk/soar/portfolio/enums/OptionType.java
+++ b/server/src/main/java/com/konkuk/soar/portfolio/enums/OptionType.java
@@ -1,0 +1,24 @@
+package com.konkuk.soar.portfolio.enums;
+
+public enum OptionType {
+  NEWEST("newest"),
+  OLDEST("oldest"),
+  RANK("rank"),
+  PUBLIC("public"),
+  PRIVATE("private");
+
+  private final String name;
+
+  OptionType(String name) {
+    this.name = name;
+  }
+
+  public static OptionType of(String name) {
+    for (OptionType optionType : OptionType.values()) {
+      if (optionType.name.equalsIgnoreCase(name)) {
+        return optionType;
+      }
+    }
+    throw new IllegalArgumentException("NO OptionType found for name:" + name);
+  }
+}

--- a/server/src/main/java/com/konkuk/soar/portfolio/repository/PortfolioRepository.java
+++ b/server/src/main/java/com/konkuk/soar/portfolio/repository/PortfolioRepository.java
@@ -1,8 +1,16 @@
 package com.konkuk.soar.portfolio.repository;
 
 import com.konkuk.soar.portfolio.domain.portfolio.Portfolio;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
+  List<Portfolio> findByMemberIdOrderByCreateAtAsc(Long memberId, Pageable pageable);
+  List<Portfolio> findByMemberIdOrderByCreateAtDesc(Long memberId, Pageable pageable);
+
+  List<Portfolio> findByMemberIdAndIsPublic(Long memberId, Boolean isPublic, Pageable pageable);
+
+  List<Portfolio> findByMemberId(Long memberId, Pageable pageable);
 
 }

--- a/server/src/main/java/com/konkuk/soar/portfolio/service/PortfolioService.java
+++ b/server/src/main/java/com/konkuk/soar/portfolio/service/PortfolioService.java
@@ -1,0 +1,16 @@
+package com.konkuk.soar.portfolio.service;
+
+import com.konkuk.soar.portfolio.dto.portfolio.response.PortfolioResponseDto;
+import com.konkuk.soar.portfolio.enums.OptionType;
+import java.util.List;
+
+public interface PortfolioService {
+
+  PortfolioResponseDto getPortfolioById(Long portfolioId);
+  List<PortfolioResponseDto> getPortfolioListByMember(Long memberId, OptionType optionType,
+      Integer size);
+
+  List<PortfolioResponseDto> getPortfolioListByBookmark(Long memberId);
+  List<PortfolioResponseDto> getPortfolioListByPopular();
+
+}

--- a/server/src/main/java/com/konkuk/soar/portfolio/service/ProjectService.java
+++ b/server/src/main/java/com/konkuk/soar/portfolio/service/ProjectService.java
@@ -1,0 +1,5 @@
+package com.konkuk.soar.portfolio.service;
+
+public interface ProjectService {
+
+}

--- a/server/src/main/java/com/konkuk/soar/portfolio/service/SimplePortfolioService.java
+++ b/server/src/main/java/com/konkuk/soar/portfolio/service/SimplePortfolioService.java
@@ -82,7 +82,6 @@ public class SimplePortfolioService implements PortfolioService {
     return null;
   }
 
-  @Transactional
   protected PortfolioResponseDto getResponseDto(Portfolio portfolio) {
     Member member = portfolio.getMember();
     List<PortfolioBookmark> bookmarkList = portfolio.getBookmarkList();

--- a/server/src/main/java/com/konkuk/soar/portfolio/service/SimplePortfolioService.java
+++ b/server/src/main/java/com/konkuk/soar/portfolio/service/SimplePortfolioService.java
@@ -1,0 +1,104 @@
+package com.konkuk.soar.portfolio.service;
+
+import com.konkuk.soar.common.domain.Tag;
+import com.konkuk.soar.global.exception.NotFoundException;
+import com.konkuk.soar.member.domain.Member;
+import com.konkuk.soar.portfolio.domain.portfolio.Portfolio;
+import com.konkuk.soar.portfolio.domain.portfolio.PortfolioBookmark;
+import com.konkuk.soar.portfolio.domain.portfolio.PortfolioReview;
+import com.konkuk.soar.portfolio.domain.portfolio.PortfolioTag;
+import com.konkuk.soar.portfolio.domain.project.ProjectFile;
+import com.konkuk.soar.portfolio.domain.project.ProjectStudyHistory;
+import com.konkuk.soar.portfolio.dto.portfolio.response.PortfolioResponseDto;
+import com.konkuk.soar.portfolio.dto.project.response.ProjectResponseDto;
+import com.konkuk.soar.portfolio.enums.OptionType;
+import com.konkuk.soar.portfolio.repository.PortfolioRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SimplePortfolioService implements PortfolioService {
+
+  private final PortfolioRepository portfolioRepository;
+
+  @Override
+  @Transactional
+  public PortfolioResponseDto getPortfolioById(Long portfolioId) {
+    Portfolio portfolio = portfolioRepository.findById(portfolioId)
+        .orElseThrow(() -> NotFoundException.MEMBER_NOT_FOUND);
+
+    return getResponseDto(portfolio);
+  }
+
+  @Override
+  @Transactional
+  public List<PortfolioResponseDto> getPortfolioListByMember(Long memberId, OptionType optionType,
+      Integer size) {
+
+    List<Portfolio> res;
+    switch (optionType) {
+      case NEWEST:
+        res = portfolioRepository.findByMemberIdOrderByCreateAtDesc(memberId,
+            Pageable.ofSize(size));
+        break;
+      case OLDEST:
+        res = portfolioRepository.findByMemberIdOrderByCreateAtAsc(memberId, Pageable.ofSize(size));
+        break;
+      case RANK:
+        res = null;
+        break;
+      case PUBLIC:
+        res = portfolioRepository.findByMemberIdAndIsPublic(memberId, true, Pageable.ofSize(size));
+        break;
+      case PRIVATE:
+        res = portfolioRepository.findByMemberIdAndIsPublic(memberId, false, Pageable.ofSize(size));
+        break;
+      default:
+        res = portfolioRepository.findByMemberId(memberId, Pageable.ofSize(size));
+        break;
+    }
+
+    if (res != null) {
+      return res.stream().map(portfolio -> getResponseDto(portfolio)).collect(Collectors.toList());
+    }
+
+    throw new RuntimeException();
+  }
+
+  @Override
+  public List<PortfolioResponseDto> getPortfolioListByBookmark(Long memberId) {
+    return null;
+  }
+
+  @Override
+  public List<PortfolioResponseDto> getPortfolioListByPopular() {
+    return null;
+  }
+
+  @Transactional
+  protected PortfolioResponseDto getResponseDto(Portfolio portfolio) {
+    Member member = portfolio.getMember();
+    List<PortfolioBookmark> bookmarkList = portfolio.getBookmarkList();
+    List<ProjectResponseDto> projectList = portfolio.getProjectList().stream().map(
+        project -> ProjectResponseDto.builder().project(project).portfolio(portfolio).member(member)
+            .fileList(project.getProjectFiles().stream().map(ProjectFile::getFile)
+                .collect(Collectors.toList())).studyHistoryList(
+                project.getStudyHistoryList().stream().map(ProjectStudyHistory::getStudyHistory)
+                    .collect(Collectors.toList())).build()).collect(Collectors.toList());
+
+    List<Tag> tagList = portfolio.getTagList().stream().map(PortfolioTag::getTag)
+        .collect(Collectors.toList());
+
+    List<PortfolioReview> reviewList = portfolio.getReviewList();
+
+    return PortfolioResponseDto.builder().member(member).portfolio(portfolio).tagList(tagList)
+        .reviewList(reviewList).projectList(projectList).bookmark(bookmarkList.size()).build();
+  }
+}

--- a/server/src/main/java/com/konkuk/soar/studyhistory/controller/StudyHistoryController.java
+++ b/server/src/main/java/com/konkuk/soar/studyhistory/controller/StudyHistoryController.java
@@ -1,5 +1,48 @@
 package com.konkuk.soar.studyhistory.controller;
 
+import com.konkuk.soar.common.dto.BaseResponse;
+import com.konkuk.soar.portfolio.enums.OptionType;
+import com.konkuk.soar.studyhistory.dto.response.StudyHistoryCalendarDto;
+import com.konkuk.soar.studyhistory.dto.response.StudyHistoryOverviewDto;
+import com.konkuk.soar.studyhistory.dto.response.StudyHistoryResponseDto;
+import com.konkuk.soar.studyhistory.service.StudyHistoryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/studyhistories")
 public class StudyHistoryController {
+
+  private final StudyHistoryService studyHistoryService;
+
+  @GetMapping("/{historyId}")
+  public BaseResponse<StudyHistoryResponseDto> getStudyHistoryById(@PathVariable Long historyId) {
+    StudyHistoryResponseDto result = studyHistoryService.getStudyHistoryById(historyId);
+    return BaseResponse.success(result);
+  }
+
+  @GetMapping("/calendar/{memberId}")
+  public BaseResponse<StudyHistoryCalendarDto> getStudyHistoryCalendar(@PathVariable Long memberId,
+      @RequestParam Integer month, @RequestParam Integer year) {
+    StudyHistoryCalendarDto result = studyHistoryService.getStudyHistoryCalendar(
+        memberId, year, month);
+    return BaseResponse.success(result);
+  }
+
+  @GetMapping
+  public BaseResponse<List<StudyHistoryOverviewDto>> getStudyHistoryList(@RequestParam Long memberId,
+      @RequestParam String option,
+      @RequestParam(required = false, defaultValue = "5") Integer size) {
+    OptionType optionType = OptionType.of(option);
+    List<StudyHistoryOverviewDto> result = studyHistoryService.getStudyHistoryListByMember(
+        memberId, optionType, size);
+    return BaseResponse.success(result);
+  }
 
 }

--- a/server/src/main/java/com/konkuk/soar/studyhistory/controller/StudyHistoryController.java
+++ b/server/src/main/java/com/konkuk/soar/studyhistory/controller/StudyHistoryController.java
@@ -1,0 +1,5 @@
+package com.konkuk.soar.studyhistory.controller;
+
+public class StudyHistoryController {
+
+}

--- a/server/src/main/java/com/konkuk/soar/studyhistory/domain/StudyHistory.java
+++ b/server/src/main/java/com/konkuk/soar/studyhistory/domain/StudyHistory.java
@@ -1,6 +1,7 @@
 package com.konkuk.soar.studyhistory.domain;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.konkuk.soar.common.domain.BaseTime;
 import com.konkuk.soar.member.domain.Member;
 import com.konkuk.soar.portfolio.domain.project.ProjectStudyHistory;
 import jakarta.persistence.Column;
@@ -30,7 +31,7 @@ import org.hibernate.validator.constraints.Length;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "study_histories")
-public class StudyHistory {
+public class StudyHistory extends BaseTime {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/server/src/main/java/com/konkuk/soar/studyhistory/dto/response/StudyHistoryCalendarDto.java
+++ b/server/src/main/java/com/konkuk/soar/studyhistory/dto/response/StudyHistoryCalendarDto.java
@@ -1,0 +1,47 @@
+package com.konkuk.soar.studyhistory.dto.response;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StudyHistoryCalendarDto {
+
+  private Integer year;
+  private Integer month;
+  private Map<Integer, List<StudyHistoryOverviewDto>> dayMap;
+
+  @Builder
+  public StudyHistoryCalendarDto(List<StudyHistoryOverviewDto> dtoList, int year, int month) {
+    this.year = year;
+    this.month = month;
+    dayMap = new HashMap<>();
+
+    int startDay, endDay;
+    for (StudyHistoryOverviewDto history : dtoList) {
+      startDay = history.getStartDate().getDayOfMonth();
+      endDay = history.getEndDate().getDayOfMonth();
+
+      if (!dayMap.containsKey(startDay)) {
+        dayMap.put(startDay, new ArrayList<>());
+      }
+
+      List<StudyHistoryOverviewDto> list = dayMap.get(startDay);
+      list.add(history);
+
+      if (startDay != endDay) {
+        if (!dayMap.containsKey(endDay)) {
+          dayMap.put(endDay, new ArrayList<>());
+        }
+
+        List<StudyHistoryOverviewDto> elist = dayMap.get(endDay);
+        elist.add(history);
+      }
+    }
+  }
+}

--- a/server/src/main/java/com/konkuk/soar/studyhistory/dto/response/StudyHistoryMetaResponseDto.java
+++ b/server/src/main/java/com/konkuk/soar/studyhistory/dto/response/StudyHistoryMetaResponseDto.java
@@ -6,8 +6,10 @@ import com.konkuk.soar.studyhistory.domain.StudyHistory;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class StudyHistoryMetaResponseDto {
 
   private Long id;

--- a/server/src/main/java/com/konkuk/soar/studyhistory/dto/response/StudyHistoryOverviewDto.java
+++ b/server/src/main/java/com/konkuk/soar/studyhistory/dto/response/StudyHistoryOverviewDto.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class StudyHistoryMetaResponseDto {
+public class StudyHistoryOverviewDto {
 
   private Long id;
   private String type;
@@ -23,7 +23,7 @@ public class StudyHistoryMetaResponseDto {
   private LocalDateTime endDate;
 
   @Builder
-  public StudyHistoryMetaResponseDto(StudyHistory history, Member member) {
+  public StudyHistoryOverviewDto(StudyHistory history, Member member) {
     this.id = history.getId();
     this.type = history.getType();
     this.content = history.getContent();

--- a/server/src/main/java/com/konkuk/soar/studyhistory/dto/response/StudyHistoryResponseDto.java
+++ b/server/src/main/java/com/konkuk/soar/studyhistory/dto/response/StudyHistoryResponseDto.java
@@ -10,8 +10,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class StudyHistoryResponseDto {
 
   private Long id;

--- a/server/src/main/java/com/konkuk/soar/studyhistory/dto/response/StudyHistoryResponseDto.java
+++ b/server/src/main/java/com/konkuk/soar/studyhistory/dto/response/StudyHistoryResponseDto.java
@@ -6,6 +6,7 @@ import com.konkuk.soar.common.domain.Tag;
 import com.konkuk.soar.member.domain.Member;
 import com.konkuk.soar.studyhistory.domain.StudyHistory;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Builder;
@@ -27,8 +28,8 @@ public class StudyHistoryResponseDto {
   private LocalDateTime endDate;
   private Long memberId;
   private String timelapseURL;
-  private List<String> files;
-  private List<String> tags;
+  private List<String> files = new ArrayList<>();
+  private List<String> tags = new ArrayList<>();
 
   @Builder
   public StudyHistoryResponseDto(StudyHistory history, Member member, File timelapseFile,
@@ -42,7 +43,12 @@ public class StudyHistoryResponseDto {
     this.startDate = history.getStartDate();
     this.endDate = history.getEndDate();
     this.memberId = member.getId();
-    timelapseURL = timelapseFile.getUrl();
+
+    timelapseURL = null;
+    if (timelapseFile != null) {
+      timelapseURL = timelapseFile.getUrl();
+    }
+
     files = fileList.stream()
         .map(f -> f.getUrl())
         .collect(Collectors.toList());

--- a/server/src/main/java/com/konkuk/soar/studyhistory/repository/StudyHistoryRepository.java
+++ b/server/src/main/java/com/konkuk/soar/studyhistory/repository/StudyHistoryRepository.java
@@ -1,8 +1,21 @@
 package com.konkuk.soar.studyhistory.repository;
 
 import com.konkuk.soar.studyhistory.domain.StudyHistory;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudyHistoryRepository extends JpaRepository<StudyHistory, Long> {
+
+  List<StudyHistory> findByStartDateBetweenAndMemberId(LocalDateTime start, LocalDateTime end,Long memberId);
+  List<StudyHistory> findByEndDateBetweenAndMemberId(LocalDateTime start, LocalDateTime end,Long memberId);
+  //TODO : CreateAt으로 할지, StartDate로 할지
+  List<StudyHistory> findByMemberIdOrderByCreateAtAsc(Long memberId, Pageable pageable);
+  List<StudyHistory> findByMemberIdOrderByCreateAtDesc(Long memberId, Pageable pageable);
+  List<StudyHistory> findByMemberIdAndIsPublic(Long memberId, Boolean isPublic, Pageable pageable);
+
+  List<StudyHistory> findByMemberId(Long memberId, Pageable pageable);
+
 
 }

--- a/server/src/main/java/com/konkuk/soar/studyhistory/service/SimpleStudyHistoryService.java
+++ b/server/src/main/java/com/konkuk/soar/studyhistory/service/SimpleStudyHistoryService.java
@@ -1,0 +1,135 @@
+package com.konkuk.soar.studyhistory.service;
+
+import com.konkuk.soar.common.domain.File;
+import com.konkuk.soar.common.domain.Tag;
+import com.konkuk.soar.common.enums.FileType;
+import com.konkuk.soar.global.exception.NotFoundException;
+import com.konkuk.soar.member.domain.Member;
+import com.konkuk.soar.portfolio.enums.OptionType;
+import com.konkuk.soar.studyhistory.domain.StudyHistory;
+import com.konkuk.soar.studyhistory.domain.StudyHistoryFile;
+import com.konkuk.soar.studyhistory.domain.StudyHistoryTag;
+import com.konkuk.soar.studyhistory.dto.response.StudyHistoryCalendarDto;
+import com.konkuk.soar.studyhistory.dto.response.StudyHistoryOverviewDto;
+import com.konkuk.soar.studyhistory.dto.response.StudyHistoryResponseDto;
+import com.konkuk.soar.studyhistory.repository.StudyHistoryRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SimpleStudyHistoryService implements StudyHistoryService {
+
+  private final StudyHistoryRepository studyHistoryRepository;
+
+  @Override
+  @Transactional
+  public StudyHistoryResponseDto getStudyHistoryById(Long historyId) {
+    StudyHistory studyHistory = studyHistoryRepository.findById(historyId)
+        .orElseThrow(() -> NotFoundException.STUDY_HISTORY_NOT_FOUND);
+    return getDto(studyHistory);
+  }
+
+  @Override
+  @Transactional
+  public StudyHistoryCalendarDto getStudyHistoryCalendar(Long memberId, Integer year,
+      Integer month) {
+    LocalDateTime start = LocalDateTime.of(LocalDate.of(year, month, 1), LocalTime.MIN);
+    int lastDay = YearMonth.of(year, month).atEndOfMonth().getDayOfMonth();
+    LocalDateTime end = LocalDateTime.of(LocalDate.of(year, month, lastDay), LocalTime.MAX);
+
+    List<StudyHistory> historyList = studyHistoryRepository.findByStartDateBetweenAndMemberId(start,
+        end, memberId);
+
+    List<StudyHistoryOverviewDto> dtoList = historyList.stream()
+        .map(this::getOverview)
+        .toList();
+
+    return StudyHistoryCalendarDto.builder()
+        .year(year)
+        .month(month)
+        .dtoList(dtoList)
+        .build();
+  }
+
+  @Override
+  public List<StudyHistoryOverviewDto> getStudyHistoryListByMember(Long memberId, OptionType option,
+      Integer size) {
+
+    List<StudyHistory> res = null;
+
+    switch (option) {
+      case NEWEST:
+        res = studyHistoryRepository.findByMemberIdOrderByCreateAtDesc(memberId,
+            Pageable.ofSize(size));
+        break;
+      case OLDEST:
+        res = studyHistoryRepository.findByMemberIdOrderByCreateAtAsc(memberId,
+            Pageable.ofSize(size));
+        break;
+      case PUBLIC:
+        res = studyHistoryRepository.findByMemberIdAndIsPublic(memberId, true,
+            Pageable.ofSize(size));
+        break;
+      case PRIVATE:
+        res = studyHistoryRepository.findByMemberIdAndIsPublic(memberId, false,
+            Pageable.ofSize(size));
+        break;
+      case RANK:
+      default:
+        res = studyHistoryRepository.findByMemberId(memberId, Pageable.ofSize(size));
+        break;
+    }
+
+    if (res != null) {
+      return res.stream()
+          .map(this::getOverview)
+          .toList();
+    }
+
+    throw new RuntimeException();
+  }
+
+  private StudyHistoryOverviewDto getOverview(StudyHistory history) {
+    Member member = history.getMember();
+    return StudyHistoryOverviewDto.builder()
+        .member(member)
+        .history(history)
+        .build();
+  }
+  private StudyHistoryResponseDto getDto(StudyHistory studyHistory) {
+
+    Member member = studyHistory.getMember();
+    List<Tag> tagList = studyHistory.getTagList().stream()
+        .map(StudyHistoryTag::getTag)
+        .toList();
+    List<File> fileList = studyHistory.getFileList().stream()
+        .map(StudyHistoryFile::getFile)
+        .filter(file -> !FileType.of(file.getType()).equals(FileType.TIMELAPSE))
+        .toList();
+
+    File timelapse = studyHistory.getFileList().stream()
+        .map(StudyHistoryFile::getFile)
+        .filter(file -> FileType.of(file.getType()).equals(FileType.TIMELAPSE))
+        .findFirst()
+        .orElse(null);
+
+    return StudyHistoryResponseDto.builder()
+        .history(studyHistory)
+        .member(member)
+        .tagList(tagList)
+        .fileList(fileList)
+        .timelapseFile(timelapse)
+        .build();
+  }
+
+}

--- a/server/src/main/java/com/konkuk/soar/studyhistory/service/StudyHistoryService.java
+++ b/server/src/main/java/com/konkuk/soar/studyhistory/service/StudyHistoryService.java
@@ -1,0 +1,17 @@
+package com.konkuk.soar.studyhistory.service;
+
+import com.konkuk.soar.portfolio.enums.OptionType;
+import com.konkuk.soar.studyhistory.dto.response.StudyHistoryCalendarDto;
+import com.konkuk.soar.studyhistory.dto.response.StudyHistoryOverviewDto;
+import com.konkuk.soar.studyhistory.dto.response.StudyHistoryResponseDto;
+import java.util.List;
+
+public interface StudyHistoryService {
+
+  StudyHistoryResponseDto getStudyHistoryById(Long historyId);
+
+  StudyHistoryCalendarDto getStudyHistoryCalendar(Long memberId, Integer year, Integer month);
+
+  List<StudyHistoryOverviewDto> getStudyHistoryListByMember(Long memberId, OptionType option,
+      Integer size);
+}

--- a/server/src/main/resources/data.sql
+++ b/server/src/main/resources/data.sql
@@ -1,0 +1,127 @@
+DELETE
+FROM PORTFOLIO_BOOKMARKS;
+DELETE
+FROM PORTFOLIO_REVIEWS;
+DELETE
+FROM PORTFOLIO_TAGS;
+
+
+DELETE
+FROM PROJECT_FILES;
+DELETE
+FROM PROJECT_STUDY_HISTORIES;
+
+
+DELETE
+FROM STUDY_HISTORY_FILE;
+DELETE
+FROM STUDY_HISTORY_TAGS;
+
+
+DELETE
+FROM TAGS;
+DELETE
+FROM FILES;
+
+DELETE
+FROM STUDY_HISTORIES;
+DELETE
+FROM PROJECTS;
+DELETE
+FROM PORTFOLIOS;
+DELETE
+FROM MEMBERS;
+
+
+INSERT INTO MEMBERS(MEMBER_ID, MEMBER_NAME)
+values (1, 'memberA'),
+       (2, 'memberB'),
+       (3, 'memberC');
+
+
+INSERT INTO TAGS(TAG_ID, NAME)
+VALUES (1, '개발'),
+       (2, '자바'),
+       (3, '스프링'),
+       (4, '리액트'),
+       (5, '백엔드'),
+       (6, '프론트엔드');
+
+
+INSERT INTO FILES (FILE_ID, FILE_TYPE, FILE_ORIGINAL_NAME, FILE_SAVED_NAME, FILE_URL)
+VALUES (1, 'zip', 'memberAFile.zip', 'userId1/memberAFile.zip', 'remote/userId1/memberAFile.zip'),
+       (2, 'timelapse', 'memberATimelapse.mp4', 'userId1/memberATimelapse.mp4',
+        'remote/userId1/memberATimelapse.mp4'),
+       (3, 'zip', 'memberBFile.zip', 'userId1/memberBFile.zip', 'remote/userId1/memberBFile.zip'),
+       (4, 'zip', 'memberCFile.zip', 'userId1/memberCFile.zip', 'remote/userId1/memberCFile.zip');
+
+
+INSERT INTO PORTFOLIOS(PORTFOLIO_ID, PORTFOLIO_MEMBER_ID, PORTFOLIO_IS_PUBLIC, PORTFOLIO_TITLE,
+                       PORTFOLIO_CATEGORY, PORTFOLIO_DESCRIPTION)
+VALUES (1, 1, true, 'portfolio of A 1', '개발 || 백엔드 || 스프링', '스프링 고수가 되보자'),
+       (2, 1, true, 'portfolio of A 2', '개발 || 백엔드 || 스프링', '스프링 중수가 되보자'),
+       (3, 1, true, 'portfolio of A 3', '개발 || 프론트엔드 || 리액트', '리액트 고수가 되보자');
+
+
+INSERT INTO PORTFOLIO_TAGS (PT_PORTFOLIO_ID, PT_TAG_ID)
+VALUES (1, 1),
+       (1, 2),
+       (1, 3),
+       (1, 5),
+       (2, 1),
+       (2, 2),
+       (2, 3),
+       (2, 5),
+       (3, 1),
+       (3, 4),
+       (3, 6);
+
+
+INSERT INTO PORTFOLIO_BOOKMARKS(PB_MEMBER_ID, PB_PORTFOLIO_ID)
+VALUES (2, 1),
+       (3, 1);
+
+
+INSERT INTO PORTFOLIO_REVIEWS(PR_PORTFOLIO_ID, PR_MEMBER_ID, PR_DIFFERENCE_SCORE,
+                              PR_EXPERTISE_SCORE, PR_PERFECTION_SCORE,
+                              PR_COMMENT)
+VALUES (1, 2, 4.0, 3.5, 4.5, '재밌게 잘 봤읍니다'),
+       (1, 3, 3.0, 3.0, 3.0, '그저 그랬음');
+
+
+INSERT INTO PROJECTS (PROJECT_ID, PROJECT_PORTFOLIO_ID, PROJECT_START_DATE, PROJECT_END_DATE,
+                      PROJECT_CATEGORY, PROJECT_DESIGN_BACKGROUND, PROJECT_ROLE, PROJECT_TITLE,
+                      PROJECT_DESCRIPTION)
+VALUES (1, 1, '2023-08-10 12:00', '2023-08-12 12:00', '스프링', '#eeeeee', '팀장', '스프링 부수기',
+        '스프링을 부수는 프로젝트'),
+       (2, 1, '2023-08-14 12:00', '2023-08-16 12:00', 'JPA', '#ffffff', '팀원', 'JPA 부수기',
+        'JPA를 부수는 프로젝트');
+
+
+INSERT INTO PROJECT_FILES(PF_FILE_ID, PF_PROJECT_ID)
+VALUES (1, 1);
+
+
+INSERT INTO STUDY_HISTORIES (STUDY_HISTORY_ID, STUDY_HISTORY_MEMBER_ID, STUDY_HISTORY_START_DATE,
+                             STUDY_HISTORY_END_DATE, STUDY_HISTORY_IS_OPEN, STUDY_HISTORY_TYPE,
+                             STUDY_HISTORY_CATEGORY, STUDY_HISTORY_CONTENT)
+VALUES (1, 1, '2023-08-11 13:00', '2023-08-11 14:00', true, '스프링', '개발 || 백엔드 || 스프링', '스프링 DI 박살'),
+       (2, 1, '2023-08-11 13:00', '2023-08-11 14:00', true, '스프링', '개발 || 백엔드 || 스프링', '자바 스트림 박살');
+
+
+INSERT INTO STUDY_HISTORY_TAGS(SHT_STUDY_HISTORY_ID, SHT_TAG_ID)
+VALUES (1,1),
+       (1,2),
+       (1,3),
+       (1,5),
+       (2,1),
+       (2,2);
+
+
+INSERT INTO STUDY_HISTORY_FILE(SHF_STUDY_HISTORY_ID, SHF_FILE_ID)
+VALUES (1, 1);
+
+
+INSERT INTO PROJECT_STUDY_HISTORIES(PSH_PROJECT_ID, PSH_STUDY_HISTORY_ID)
+VALUES (1, 1),
+       (1, 2);

--- a/server/src/main/resources/data.sql
+++ b/server/src/main/resources/data.sql
@@ -57,10 +57,17 @@ VALUES (1, 'zip', 'memberAFile.zip', 'userId1/memberAFile.zip', 'remote/userId1/
 
 
 INSERT INTO PORTFOLIOS(PORTFOLIO_ID, PORTFOLIO_MEMBER_ID, PORTFOLIO_IS_PUBLIC, PORTFOLIO_TITLE,
-                       PORTFOLIO_CATEGORY, PORTFOLIO_DESCRIPTION)
-VALUES (1, 1, true, 'portfolio of A 1', '개발 || 백엔드 || 스프링', '스프링 고수가 되보자'),
-       (2, 1, true, 'portfolio of A 2', '개발 || 백엔드 || 스프링', '스프링 중수가 되보자'),
-       (3, 1, true, 'portfolio of A 3', '개발 || 프론트엔드 || 리액트', '리액트 고수가 되보자');
+                       PORTFOLIO_CATEGORY, PORTFOLIO_DESCRIPTION, create_at, update_at)
+VALUES (1, 1, true, 'portfolio of A 1', '개발 || 백엔드 || 스프링', '스프링 고수가 되보자', '2023-01-01 17:00',
+        '2023-01-01 17:00'),
+       (2, 1, true, 'portfolio of A 2', '개발 || 백엔드 || 스프링', '스프링 중수가 되보자', '2023-02-01 17:00',
+        '2023-02-01 17:00'),
+       (3, 1, true, 'portfolio of A 3', '개발 || 프론트엔드 || 리액트', '리액트 고수가 되보자', '2023-03-01 17:00',
+        '2023-03-01 17:00'),
+       (4, 1, false, 'portfolio of A 4', '개발 || 프론트엔드 || Vue', 'Vue 고수가 되보자', '2023-05-01 18:00',
+        '2023-05-01 17:00');
+
+
 
 
 INSERT INTO PORTFOLIO_TAGS (PT_PORTFOLIO_ID, PT_TAG_ID)
@@ -110,12 +117,12 @@ VALUES (1, 1, '2023-08-11 13:00', '2023-08-11 14:00', true, '스프링', '개발
 
 
 INSERT INTO STUDY_HISTORY_TAGS(SHT_STUDY_HISTORY_ID, SHT_TAG_ID)
-VALUES (1,1),
-       (1,2),
-       (1,3),
-       (1,5),
-       (2,1),
-       (2,2);
+VALUES (1, 1),
+       (1, 2),
+       (1, 3),
+       (1, 5),
+       (2, 1),
+       (2, 2);
 
 
 INSERT INTO STUDY_HISTORY_FILE(SHF_STUDY_HISTORY_ID, SHF_FILE_ID)

--- a/server/src/main/resources/data.sql
+++ b/server/src/main/resources/data.sql
@@ -49,11 +49,14 @@ VALUES (1, '개발'),
 
 
 INSERT INTO FILES (FILE_ID, FILE_TYPE, FILE_ORIGINAL_NAME, FILE_SAVED_NAME, FILE_URL)
-VALUES (1, 'zip', 'memberAFile.zip', 'userId1/memberAFile.zip', 'remote/userId1/memberAFile.zip'),
+VALUES (1, 'normal', 'memberAFile.zip', 'userId1/memberAFile.zip',
+        'remote/userId1/memberAFile.zip'),
        (2, 'timelapse', 'memberATimelapse.mp4', 'userId1/memberATimelapse.mp4',
         'remote/userId1/memberATimelapse.mp4'),
-       (3, 'zip', 'memberBFile.zip', 'userId1/memberBFile.zip', 'remote/userId1/memberBFile.zip'),
-       (4, 'zip', 'memberCFile.zip', 'userId1/memberCFile.zip', 'remote/userId1/memberCFile.zip');
+       (3, 'normal', 'memberBFile.zip', 'userId1/memberBFile.zip',
+        'remote/userId1/memberBFile.zip'),
+       (4, 'normal', 'memberCFile.zip', 'userId1/memberCFile.zip',
+        'remote/userId1/memberCFile.zip');
 
 
 INSERT INTO PORTFOLIOS(PORTFOLIO_ID, PORTFOLIO_MEMBER_ID, PORTFOLIO_IS_PUBLIC, PORTFOLIO_TITLE,
@@ -66,7 +69,6 @@ VALUES (1, 1, true, 'portfolio of A 1', '개발 || 백엔드 || 스프링', '스
         '2023-03-01 17:00'),
        (4, 1, false, 'portfolio of A 4', '개발 || 프론트엔드 || Vue', 'Vue 고수가 되보자', '2023-05-01 18:00',
         '2023-05-01 17:00');
-
 
 
 
@@ -111,9 +113,16 @@ VALUES (1, 1);
 
 INSERT INTO STUDY_HISTORIES (STUDY_HISTORY_ID, STUDY_HISTORY_MEMBER_ID, STUDY_HISTORY_START_DATE,
                              STUDY_HISTORY_END_DATE, STUDY_HISTORY_IS_OPEN, STUDY_HISTORY_TYPE,
-                             STUDY_HISTORY_CATEGORY, STUDY_HISTORY_CONTENT)
-VALUES (1, 1, '2023-08-11 13:00', '2023-08-11 14:00', true, '스프링', '개발 || 백엔드 || 스프링', '스프링 DI 박살'),
-       (2, 1, '2023-08-11 13:00', '2023-08-11 14:00', true, '스프링', '개발 || 백엔드 || 스프링', '자바 스트림 박살');
+                             STUDY_HISTORY_CATEGORY, STUDY_HISTORY_CONTENT, create_at, update_at)
+VALUES (1, 1, '2023-08-11 13:00', '2023-08-11 14:00', true, '스프링', '개발 || 백엔드 || 스프링', '스프링 DI 박살',
+        '2023-01-01 17:00',
+        '2023-01-01 17:00'),
+       (2, 1, '2023-08-12 13:00', '2023-08-12 14:00', true, '스프링', '개발 || 백엔드 || 스프링', '자바 스트림 박살',
+        '2023-02-01 17:00',
+        '2023-02-01 17:00'),
+       (3, 1, '2023-09-12 13:00', '2023-08-12 14:00', true, '영어', '영어 || 토익', '토익 공부',
+        '2023-03-01 17:00',
+        '2023-03-01 17:00');
 
 
 INSERT INTO STUDY_HISTORY_TAGS(SHT_STUDY_HISTORY_ID, SHT_TAG_ID)
@@ -126,7 +135,8 @@ VALUES (1, 1),
 
 
 INSERT INTO STUDY_HISTORY_FILE(SHF_STUDY_HISTORY_ID, SHF_FILE_ID)
-VALUES (1, 1);
+VALUES (1, 1),
+       (1, 2);
 
 
 INSERT INTO PROJECT_STUDY_HISTORIES(PSH_PROJECT_ID, PSH_STUDY_HISTORY_ID)

--- a/server/src/main/resources/mock/portfolio.json
+++ b/server/src/main/resources/mock/portfolio.json
@@ -1,0 +1,65 @@
+{
+  "portfolioId": 1,
+  "memberId": 1,
+  "title": "test portfolio title",
+  "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit Curabitur imperdiet dui a nisl aliquam ornare. Morbi sit amet viverra odio. Nunc elementum volutpat sapien, consectetur pulvinar elit dignissim ac. Morbi non turpis sed velit iaculis varius. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ornare non magna in facilisis. Nullam sit amet laoreet diam. Pellentesque et metus erat. Etiam posuere arcu lorem.",
+  "category": "개발 || 백엔드 || 스프링",
+  "bookmark": 5,
+  "projects": [
+    {
+      "projectId": 1,
+      "portfolioId": 1,
+      "title": "test project title",
+      "category": "개발 || 백엔드 || 스프링",
+      "role": "팀원",
+      "description": "스프링 부수기 프로젝트",
+      "startDate": "2023-08-10 15",
+      "endDate": "2023-08-11 15",
+      "studyHistories": [
+        {
+          "id": 1,
+          "type": "개발",
+          "content": "스프링 공부",
+          "memberId": 1,
+          "category": "개발 || 백엔드 || 스프링",
+          "startDate": "2023-08-10 12:00",
+          "endDate": "2023-08-10 15:34"
+        },
+        {
+          "id": 2,
+          "type": "개발",
+          "content": "자바 공부",
+          "memberId": 1,
+          "category": "개발 || 백엔드 || 자바",
+          "startDate": "2023-08-11 16:34",
+          "endDate": "2023-08-11 19:34"
+        }
+      ],
+      "files": [
+        {
+          "fileId": 1,
+          "type": "img",
+          "fileName": "project1 capture image",
+          "url": "test/image/myimage.jpg"
+        }
+      ]
+    }
+  ],
+  "reviews": [
+    {
+      "memberId": 2,
+      "portfolioId": 1,
+      "expertiseScore": 4.0,
+      "differenceScore": 3.5,
+      "perfectionScore": 4.5,
+      "comment": "잘 봤습니다."
+    }
+  ],
+  "tags": {
+    "name": [
+      "자바",
+      "스프링",
+      "백엔드"
+    ]
+  }
+}


### PR DESCRIPTION
## 개요
- #6
- Mockup 서버를 위한 컨트롤러 및 swagger 적용

## 작업사항

- 학습기록 컨트롤러 구현
- 포트폴리오 컨트롤러 구현
- mockup data sql
- swagger 적용

## 변경로직

- 일부 도메인들에 BaseTime 엔티티 상속 (createAt, updateAt 사용 목적)
- 기본적인 컨트롤러 구현
- Swagger 적용
