### PR TITLE
로그 수집 설정

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -43,3 +43,6 @@ target
 secrets.yml
 .gradletasknamecache
 .sts4-cache
+
+#log file ignore
+**/*.log

--- a/server/src/main/resources/logback-spring.xml
+++ b/server/src/main/resources/logback-spring.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+  <conversionRule conversionWord="clr"
+    converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+  <property name="CONSOLE_LOG_PATTERN"
+    value="%blue(%d{yyyy-MM-dd HH:mm:ss.SSS}) %magenta([%thread]) %clr(%5level) %cyan(%logger) - %msg%n"/>
+  <property name="FILE_LOG_PATTERN"
+    value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %5level %logger - %msg%n"/>
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+    </encoder>
+  </appender>
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <encoder>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>./log/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <maxFileSize>100MB</maxFileSize>
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
+  </appender>
+
+  <springProfile name="dev|create">
+    <root level="INFO">
+      <appender-ref ref="CONSOLE"/>
+    </root>
+  </springProfile>
+  <springProfile name="prod">
+    <root level="ERROR">
+      <appender-ref ref="CONSOLE"/>
+      <appender-ref ref="FILE"/>
+    </root>
+  </springProfile>
+</configuration>


### PR DESCRIPTION
## 개요
- #29 

## 작업사항
- 날짜 별로 ./log/날짜.log 파일에 로그 수집하도록 설정
- dev|create profile에서는 콘솔에 INFO level로 로그 출력
- prod profile에서는 콘솔 및 파일에 ERROR level로 로그 출력

## 변경로직

- gitignore에 `**/*.log` 추가
